### PR TITLE
Fix webpack/babel notice

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -30,6 +30,7 @@
 				"web-vitals": "^3.3.1"
 			},
 			"devDependencies": {
+				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
 				"@testing-library/jest-dom": "^5.16.5",
 				"@testing-library/react": "^14.0.0",
 				"@testing-library/user-event": "^14.4.3"
@@ -769,9 +770,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-private-property-in-object": {
-			"version": "7.21.0-placeholder-for-preset-env.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+			"version": "7.21.11",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+			"integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.18.6",
+				"@babel/helper-create-class-features-plugin": "^7.21.0",
+				"@babel/helper-plugin-utils": "^7.20.2",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+			},
 			"engines": {
 				"node": ">=6.9.0"
 			},
@@ -2007,6 +2016,17 @@
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+			"version": "7.21.0-placeholder-for-preset-env.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
 			"engines": {
 				"node": ">=6.9.0"
 			},

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -38,6 +38,7 @@
 		"web-vitals": "^3.3.1"
 	},
 	"devDependencies": {
+		"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/react": "^14.0.0",
 		"@testing-library/user-event": "^14.4.3"


### PR DESCRIPTION
Add @babel/plugin-proposal-private-property-in-object to devDeps to resolve the warning when the dev server starts.