### PR TITLE
exclude macOS .DS_Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# macOS
+.DS_Store


### PR DESCRIPTION
prevents a macOS specific dotfile from being tracked