### PR TITLE
rename container test for about page

### DIFF
--- a/src/client/src/__tests__/About.test.js
+++ b/src/client/src/__tests__/About.test.js
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import About from "../components/About";
 
 describe("About component", () => {
-  test("About component render container", () => {
+  test("About container element is present in the document", () => {
     render(<About />);
     const conElement = screen.getByTestId("about-container");
     expect(conElement).toBeInTheDocument();


### PR DESCRIPTION
Opening pull request for #70 

## Summary
This commit adopts the naming convention suggested in associated issue #70.

---

Also, I was goofy and inadvertently created [this branch](https://github.com/gbowne1/TwitchBot/tree/70-test-about-component-test-has-duplicated-names-in-the-test) on the main repo instead of my fork so it can probably be deleted.