### PR TITLE
Remove deprecated CSS properties

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -3,8 +3,6 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 code {


### PR DESCRIPTION
opening a PR for #50

This PR removes the two offending CSS properties: `-webkit-font-smoothing` and `-moz-osx-font-smoothing`
