### PR TITLE
Resolve Deprecation warnings in Github Actions

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install dependencies for client
-        run: cd src/client && npm install
+        run: cd src/client && npm ci
 
       - name: Install dependencies for server
-        run: cd src/server && npm install
+        run: cd src/server && npm ci
 
       # Run Prettier
       - name: Run Prettier for client

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
 


### PR DESCRIPTION
Opening a PR for #79 

After checking [a run in the actions](https://github.com/gbowne1/TwitchBot/actions/runs/8123270595), I noted some deprecation warnings under annotations. This PR fixes #79. ~It has [run successfully on my fork](https://github.com/jarmentor/TwitchBot/actions/runs/8123418683) as expected.~ Edit: this was the old action, but I'm relatively confident that [this functions](https://github.com/gbowne1/TwitchBot/actions/runs/8123437444/job/22203843338?pr=80).