### PR TITLE
Resolve cross origin login errors between server and client (#72)

### DIFF
--- a/src/client/src/context/authContext.js
+++ b/src/client/src/context/authContext.js
@@ -11,7 +11,7 @@ export const AuthContextProvider = ({ children }) => {
 
   const login = async (inputs) => {
     try {
-      const res = await axios.post("http://localhost:3000/login", inputs, {
+      const res = await axios.post("http://localhost:3001/login", inputs, {
         withCredentials: true,
       });
       setCurrentUser(res.data);
@@ -23,7 +23,7 @@ export const AuthContextProvider = ({ children }) => {
 
   const logout = async () => {
     try {
-      await axios.post("http://localhost:3000/logout");
+      await axios.post("http://localhost:3001/logout");
       setCurrentUser(null);
     } catch (error) {
       // Handle login error

--- a/src/server/.env-example
+++ b/src/server/.env-example
@@ -6,3 +6,5 @@ MONGO_URI=mongodb://localhost:27017/twitchbot
 TWITCH_USERNAME=
 TWITCH_PASSWORD=
 TWITCH_CHANNEL=
+# JWT Secret
+SECRET_KEY=

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -9,7 +9,7 @@ const bcrypt = require("bcrypt");
 dotenv.config();
 const app = express();
 app.use(express.json());
-app.use(cors({ origin: "http://localhost:3001", credentials: true }));
+app.use(cors({ origin: "http://localhost:3000", credentials: true }));
 app.use(cookieParser());
 
 let mongoURI =


### PR DESCRIPTION
Opening a PR to resolve #72 

This PR:
 - modifies the allowed origin in the `server.js` file to permit the client running on port 3000 to access its resources.
 - modifies the `authContext.js` to hit the server at port 3001 and not the client at port 3000.
 - QoL - Adds the `SECRET_KEY` to the `.env-example` file in an effort to remember to set it.