### PR TITLE
Reference theme color via hook

### DIFF
--- a/src/client/src/components/DrawerMenu.js
+++ b/src/client/src/components/DrawerMenu.js
@@ -6,14 +6,18 @@ import ListItemText from "@mui/material/ListItemText";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { routes } from "../routes";
+import { useTheme } from "@mui/material/styles";
 
 const DrawerMenu = (props) => {
   const navRoutes = routes.filter((route) => route.inNav);
+
+  const theme = useTheme();
+
   return (
     <Drawer anchor="left" open={props.isOpen} onClose={props.onClose}>
       <List>
         {navRoutes.map((route, index) => (
-          <ListItem key={index} sx={{ color: "palette.text.primary" }}>
+          <ListItem key={index} sx={{ color: theme.palette.text.primary }}>
             <Link
               to={route.path}
               style={{ color: "inherit", textDecoration: "none" }}


### PR DESCRIPTION
Opening a PR to resolve #81 

While I'm unable to reproduce on my end, I believe this is the resolves the issue, if the reviewer might kindly confirm.

This PR modifies the DrawerMenu component to reference the text primary color from the theme object instead of passing "palette.text.primary" as a string.